### PR TITLE
swagger 기본 config 

### DIFF
--- a/src/main/java/com/depromeet/breadmapbackend/common/config/SwaggerConfig.java
+++ b/src/main/java/com/depromeet/breadmapbackend/common/config/SwaggerConfig.java
@@ -14,7 +14,7 @@ import springfox.documentation.spring.web.plugins.Docket;
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
 @Configuration
-@Profile({"dev"}) //dev 환경에서만 Swagger 동작하도록 설정
+@Profile({"dev"}) //dev 환경에서만 Swagger 동작하도록 설정(run configuration의 VM option: -Dspring.profiles.active=dev 설정 필요)
 @EnableSwagger2
 public class SwaggerConfig implements WebMvcConfigurer {
 

--- a/src/main/java/com/depromeet/breadmapbackend/common/config/SwaggerConfig.java
+++ b/src/main/java/com/depromeet/breadmapbackend/common/config/SwaggerConfig.java
@@ -1,31 +1,20 @@
 package com.depromeet.breadmapbackend.common.config;
 
-import io.swagger.annotations.Info;
-import io.swagger.annotations.SwaggerDefinition;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
-import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import springfox.documentation.builders.ApiInfoBuilder;
 import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.builders.RequestHandlerSelectors;
-import springfox.documentation.builders.ResponseMessageBuilder;
 import springfox.documentation.service.ApiInfo;
-import springfox.documentation.service.ResponseMessage;
 import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spring.web.plugins.Docket;
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
-import java.util.ArrayList;
-import java.util.List;
-
 @Configuration
-//@Profile({"!prod"}) //TODO prod 환경에서 swagger가 동작하지 않도록 하기 위한 옵션(profile prod 지정 시, 404 에러 발생할 것이므로 에러 핸들링 필요)
+@Profile({"dev"}) //dev 환경에서만 Swagger 동작하도록 설정
 @EnableSwagger2
 public class SwaggerConfig implements WebMvcConfigurer {
 

--- a/src/main/java/com/depromeet/breadmapbackend/common/config/SwaggerConfig.java
+++ b/src/main/java/com/depromeet/breadmapbackend/common/config/SwaggerConfig.java
@@ -1,0 +1,64 @@
+package com.depromeet.breadmapbackend.common.config;
+
+import io.swagger.annotations.Info;
+import io.swagger.annotations.SwaggerDefinition;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import springfox.documentation.builders.ApiInfoBuilder;
+import springfox.documentation.builders.PathSelectors;
+import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.builders.ResponseMessageBuilder;
+import springfox.documentation.service.ApiInfo;
+import springfox.documentation.service.ResponseMessage;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spring.web.plugins.Docket;
+import springfox.documentation.swagger2.annotations.EnableSwagger2;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Configuration
+//@Profile({"!prod"}) //TODO prod 환경에서 swagger가 동작하지 않도록 하기 위한 옵션(profile prod 지정 시, 404 에러 발생할 것이므로 에러 핸들링 필요)
+@EnableSwagger2
+public class SwaggerConfig implements WebMvcConfigurer {
+
+    @Value("${swagger-info.title}")
+    private String swaggerTitle;
+    @Value("${swagger-info.description}")
+    private String swaggerDescription;
+    @Value("${swagger-info.version}")
+    private String swaggerVersion;
+
+    @Bean
+    public Docket restAPI() {
+        List<ResponseMessage> responseMessageList = new ArrayList<>();
+        responseMessageList.add(new ResponseMessageBuilder().code(200).message("OK").build());
+        responseMessageList.add(new ResponseMessageBuilder().code(500).message("Server Error").build());
+        responseMessageList.add(new ResponseMessageBuilder().code(404).message("No Page").build());
+
+        return new Docket(DocumentationType.SWAGGER_2)
+                .apiInfo(apiInfo())
+                .select()
+                .apis(RequestHandlerSelectors.basePackage("com.depromeet.breadmapbackend")) // 대상 패키지 설정
+                .paths(PathSelectors.any()) // 모든 path에 대해 swagger 설정(security 필터 사용 시, swagger permitAll() 필요) TODO security 설정 시 해당 부분에 대해서는 예외 처리 필요
+                .build()
+                .useDefaultResponseMessages(false)
+                .globalResponseMessage(RequestMethod.GET, responseMessageList);
+    }
+
+    private ApiInfo apiInfo() {
+        return new ApiInfoBuilder()
+                .title(swaggerTitle)
+                .version(swaggerVersion)
+                .description(swaggerDescription)
+                .build();
+    }
+
+}

--- a/src/main/java/com/depromeet/breadmapbackend/common/config/SwaggerConfig.java
+++ b/src/main/java/com/depromeet/breadmapbackend/common/config/SwaggerConfig.java
@@ -38,19 +38,12 @@ public class SwaggerConfig implements WebMvcConfigurer {
 
     @Bean
     public Docket restAPI() {
-        List<ResponseMessage> responseMessageList = new ArrayList<>();
-        responseMessageList.add(new ResponseMessageBuilder().code(200).message("OK").build());
-        responseMessageList.add(new ResponseMessageBuilder().code(500).message("Server Error").build());
-        responseMessageList.add(new ResponseMessageBuilder().code(404).message("No Page").build());
-
         return new Docket(DocumentationType.SWAGGER_2)
                 .apiInfo(apiInfo())
                 .select()
                 .apis(RequestHandlerSelectors.basePackage("com.depromeet.breadmapbackend")) // 대상 패키지 설정
                 .paths(PathSelectors.any()) // 모든 path에 대해 swagger 설정(security 필터 사용 시, swagger permitAll() 필요) TODO security 설정 시 해당 부분에 대해서는 예외 처리 필요
-                .build()
-                .useDefaultResponseMessages(false)
-                .globalResponseMessage(RequestMethod.GET, responseMessageList);
+                .build();
     }
 
     private ApiInfo apiInfo() {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,3 +6,7 @@ spring:
     import:
       - optional:classpath:application-dev.yml
 
+swagger-info:
+  title: Daedong BreadMap REST API
+  description: Depromeet 10th Team 7
+  version: 1.0.0

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,8 +5,3 @@ spring:
   config:
     import:
       - optional:classpath:application-dev.yml
-
-swagger-info:
-  title: Daedong BreadMap REST API
-  description: Depromeet 10th Team 7
-  version: 1.0.0


### PR DESCRIPTION
## swagger 호출 법
http://localhost:8080/swagger-ui.html

## 설정 내용
* application.yml 내 title, description, version 지정하여 Value 주입
* contact의 경우 따로 쓰지 않았으나, 추가 니즈가 있을 경우 추가 예정

### 추가로 진행 필요한 내용
1. swagger 기본 config 외 API 내용 작성
> controller 등 매핑의 경우, feature/20 작업 완료 후 생성된 controller 통해 진행 예정 (필수, 이슈 따로 생성 예정)
2. profile에 따른 설정
> 현재, spring.profiles.active 값과 상관없이 swagger 호출이 가능합니다.
> prod 환경에 대해서 swagger 보이지 않도록 하기 위해서는 설정 필요(config 설정 및 404 error 핸들링)
3. 현재 http://localhost:8080/swagger-ui.html 호출 시 개발자 도구 확인 시 하기와 같이 호출하는 것을 확인할 수 있습니다.
> http://localhost:8080 (Response code: 404)
> http://localhost:8080/csrf (Response code: 404)

* 해당 내용은 springfox측에서 csrf 토큰을 보냄으로 인해 발생한 것으로 404 에러 핸들링이 필요할 경우, 하기 URL 참고 가능
[https://stackoverflow.com/questions/55582023/when-loading-the-swagger-ui-html-page-a-request-is-made-to-hostport-and-host](url)