### PR TITLE
[#32] Bakeries, BreadCategories Entity 추가 및 변경

### DIFF
--- a/src/main/java/com/depromeet/breadmapbackend/bakeries/domain/Bakeries.java
+++ b/src/main/java/com/depromeet/breadmapbackend/bakeries/domain/Bakeries.java
@@ -2,6 +2,7 @@ package com.depromeet.breadmapbackend.bakeries.domain;
 
 import com.depromeet.breadmapbackend.common.domain.BaseEntity;
 import com.depromeet.breadmapbackend.common.domain.Images;
+import com.depromeet.breadmapbackend.common.util.StringListConverter;
 import com.depromeet.breadmapbackend.flags.domain.Flags;
 import com.depromeet.breadmapbackend.members.domain.Members;
 import lombok.AllArgsConstructor;
@@ -35,12 +36,12 @@ public class Bakeries extends BaseEntity {
 
     private String businessHour;
 
-    @ElementCollection
+    @Convert(converter = StringListConverter.class)
     private List<String> websiteUrlList = new ArrayList<>();
 
     private String telNumber;
 
-    @ElementCollection
+    @Convert(converter = StringListConverter.class)
     private List<String> basicInfoList = new ArrayList<>();
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/depromeet/breadmapbackend/bakeries/domain/Bakeries.java
+++ b/src/main/java/com/depromeet/breadmapbackend/bakeries/domain/Bakeries.java
@@ -7,6 +7,7 @@ import com.depromeet.breadmapbackend.members.domain.Members;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Type;
 
 import javax.persistence.*;
 import java.util.ArrayList;
@@ -22,13 +23,6 @@ public class Bakeries extends BaseEntity {
     @Column(name = "bakery_id")
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id")
-    private Members members;
-
-    @OneToMany(mappedBy = "bakeries")
-    private List<Flags> flagsList = new ArrayList<>();
-
     @Column(nullable = false)
     private String name;
 
@@ -40,12 +34,32 @@ public class Bakeries extends BaseEntity {
 
     private String address;
 
-    @OneToMany(mappedBy = "bakeries")
-    private List<Images> exteriorImgPathList = new ArrayList<>();
+    private String businessHour;
+
+    @Type(type = "list-array")
+    @Column(columnDefinition = "text[]")
+    private List<String> websiteUrlList = new ArrayList<>();
+
+    private String telNumber;
+
+    @Type(type = "list-array")
+    @Column(columnDefinition = "text[]")
+    private List<String> basicInfoList = new ArrayList<>();
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Members members;
 
     @OneToMany(mappedBy = "bakeries")
-    private List<Images> interiorImgPathList = new ArrayList<>();
+    private List<Flags> flagsList = new ArrayList<>();
 
     @OneToMany(mappedBy = "bakeries")
-    private List<BakeriesMenusMap> bakeriesMenusMapList = new ArrayList<>();
+    private List<Images> bakeryImgPathList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "bakeries")
+    private List<BakeriesBreadCategoriesMap> bakeriesMenusMapList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "bakeries")
+    private List<Menus> menusList = new ArrayList<>();
+
 }

--- a/src/main/java/com/depromeet/breadmapbackend/bakeries/domain/Bakeries.java
+++ b/src/main/java/com/depromeet/breadmapbackend/bakeries/domain/Bakeries.java
@@ -7,7 +7,6 @@ import com.depromeet.breadmapbackend.members.domain.Members;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.Type;
 
 import javax.persistence.*;
 import java.util.ArrayList;
@@ -36,14 +35,12 @@ public class Bakeries extends BaseEntity {
 
     private String businessHour;
 
-    @Type(type = "list-array")
-    @Column(columnDefinition = "text[]")
+    @ElementCollection
     private List<String> websiteUrlList = new ArrayList<>();
 
     private String telNumber;
 
-    @Type(type = "list-array")
-    @Column(columnDefinition = "text[]")
+    @ElementCollection
     private List<String> basicInfoList = new ArrayList<>();
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/depromeet/breadmapbackend/bakeries/domain/Bakeries.java
+++ b/src/main/java/com/depromeet/breadmapbackend/bakeries/domain/Bakeries.java
@@ -52,7 +52,7 @@ public class Bakeries extends BaseEntity {
     private List<Flags> flagsList = new ArrayList<>();
 
     @OneToMany(mappedBy = "bakeries")
-    private List<Images> bakeryImgPathList = new ArrayList<>();
+    private List<Images> imgPathList = new ArrayList<>();
 
     @OneToMany(mappedBy = "bakeries")
     private List<BakeriesBreadCategoriesMap> bakeriesMenusMapList = new ArrayList<>();

--- a/src/main/java/com/depromeet/breadmapbackend/bakeries/domain/BakeriesBreadCategoriesMap.java
+++ b/src/main/java/com/depromeet/breadmapbackend/bakeries/domain/BakeriesBreadCategoriesMap.java
@@ -12,7 +12,7 @@ import javax.persistence.*;
 @Entity
 @NoArgsConstructor
 @AllArgsConstructor
-public class BakeriesMenusMap extends BaseEntity {
+public class BakeriesBreadCategoriesMap extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/depromeet/breadmapbackend/bakeries/domain/BakeriesBreadCategoriesMap.java
+++ b/src/main/java/com/depromeet/breadmapbackend/bakeries/domain/BakeriesBreadCategoriesMap.java
@@ -23,10 +23,6 @@ public class BakeriesBreadCategoriesMap extends BaseEntity {
     private Bakeries bakeries;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "menu_id")
-    private Menus menus;
-
-    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "bread_category_id")
     private BreadCategories breadCategories;
 }

--- a/src/main/java/com/depromeet/breadmapbackend/bakeries/domain/BakeriesBreadCategoriesMap.java
+++ b/src/main/java/com/depromeet/breadmapbackend/bakeries/domain/BakeriesBreadCategoriesMap.java
@@ -25,4 +25,8 @@ public class BakeriesBreadCategoriesMap extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "menu_id")
     private Menus menus;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "bread_category_id")
+    private BreadCategories breadCategories;
 }

--- a/src/main/java/com/depromeet/breadmapbackend/bakeries/domain/BreadCategories.java
+++ b/src/main/java/com/depromeet/breadmapbackend/bakeries/domain/BreadCategories.java
@@ -23,4 +23,7 @@ public class BreadCategories extends BaseEntity {
 
     @OneToMany(mappedBy = "breadCategories")
     private List<BakeriesBreadCategoriesMap> bakeriesBreadCategoriesMapList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "breadCategories")
+    private List<Menus> menusList = new ArrayList<>();
 }

--- a/src/main/java/com/depromeet/breadmapbackend/bakeries/domain/BreadCategories.java
+++ b/src/main/java/com/depromeet/breadmapbackend/bakeries/domain/BreadCategories.java
@@ -1,0 +1,26 @@
+package com.depromeet.breadmapbackend.bakeries.domain;
+
+import com.depromeet.breadmapbackend.common.domain.BaseEntity;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+public class BreadCategories extends BaseEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "bread_category_id")
+    private Long id;
+
+    private String name;
+
+    @OneToMany(mappedBy = "breadCategories")
+    private List<BakeriesBreadCategoriesMap> bakeriesBreadCategoriesMapList = new ArrayList<>();
+}

--- a/src/main/java/com/depromeet/breadmapbackend/bakeries/domain/Menus.java
+++ b/src/main/java/com/depromeet/breadmapbackend/bakeries/domain/Menus.java
@@ -28,7 +28,7 @@ public class Menus extends BaseEntity {
     private Bakeries bakeries;
 
     @OneToMany(mappedBy = "menus")
-    private List<BakeriesMenusMap> bakeriesMenusMapList = new ArrayList<>();
+    private List<BakeriesBreadCategoriesMap> bakeriesMenusMapList = new ArrayList<>();
 
 
 }

--- a/src/main/java/com/depromeet/breadmapbackend/bakeries/domain/Menus.java
+++ b/src/main/java/com/depromeet/breadmapbackend/bakeries/domain/Menus.java
@@ -27,8 +27,10 @@ public class Menus extends BaseEntity {
     @JoinColumn(name = "bakery_id")
     private Bakeries bakeries;
 
-    @OneToMany(mappedBy = "menus")
-    private List<BakeriesBreadCategoriesMap> bakeriesMenusMapList = new ArrayList<>();
+    @Column(nullable = false)
+    private String price;
 
-
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "bread_category_id")
+    private BreadCategories breadCategories;
 }

--- a/src/main/java/com/depromeet/breadmapbackend/common/util/StringListConverter.java
+++ b/src/main/java/com/depromeet/breadmapbackend/common/util/StringListConverter.java
@@ -1,0 +1,22 @@
+package com.depromeet.breadmapbackend.common.util;
+
+import javax.persistence.AttributeConverter;
+import javax.persistence.Converter;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+@Converter
+public class StringListConverter implements AttributeConverter<List<String>, String> {
+    private static final String SPLIT_CHAR = ",";
+
+    @Override
+    public String convertToDatabaseColumn(List<String> attribute) {
+        return attribute != null ? String.join(SPLIT_CHAR, attribute) : "";
+    }
+
+    @Override
+    public List<String> convertToEntityAttribute(String dbData) {
+        return dbData != null ? Arrays.asList(dbData.split(SPLIT_CHAR)) : Collections.emptyList();
+    }
+}


### PR DESCRIPTION
## 작업 내용
* Bakeries 엔티티 항목 추가
* BreadCategories 엔티티 추가
* BakeriesMenusMap 엔티티명 변경 -> 용도 변경(BakeriesBreadCategoriesMap)

## 확인 필요 사항
```
// 홈페이지의 확장성을 위해 List로 넣어보았습니다. (+Add 버튼이 무서워서요..)
@ElementCollection
private List<String> websiteUrlList = new ArrayList<>();
```

```
@ManyToOne(fetch = FetchType.LAZY)
@JoinColumn(name = "member_id")
private Members members; // 빵집 개척자를 넣는 것인데, 볼때마다 헷갈립니다.. 컬럼명 바꾸는거 어떠실지..
```

```
// 양방향이 필요할지 고민이 필요합니다..
@OneToMany(mappedBy = "bakeries")
private List<Menus> menusList = new ArrayList<>();
```

```
// BreadCategories(예: 마카롱) 선택 시 해당 카테고리가 존재하는 Bakeries를 찾아가야할 수 있다고 생각하여 양방향 설정
@OneToMany(mappedBy = "breadCategories")
private List<BakeriesBreadCategoriesMap> bakeriesBreadCategoriesMapList = new ArrayList<>();

```

@2haein 
해인님 제가 BakeriesBreadCategoriesMap 엔티티 명만 수정하였고, 그에 따른 사이드이펙(예: 컬럼명)은 수정하지 않았습니다 :)
수정 시 유의 부탁드려요~
추가) CI 에러를 참지못하고.. 연관관계 넣었습니당,, 참고해주세요!
```
    @ManyToOne(fetch = FetchType.LAZY)
    @JoinColumn(name = "bread_category_id")
    private BreadCategories breadCategories;
```