### PR TITLE
빵집 조회 누락된 컬럼 및 신규 enum 생성

### DIFF
--- a/src/main/java/com/depromeet/breadmapbackend/bakeries/dto/BakeryListResponse.java
+++ b/src/main/java/com/depromeet/breadmapbackend/bakeries/dto/BakeryListResponse.java
@@ -1,6 +1,6 @@
 package com.depromeet.breadmapbackend.bakeries.dto;
 
-import com.depromeet.breadmapbackend.reviews.domain.BakeryReviews;
+import com.depromeet.breadmapbackend.reviews.dto.BakeryReviewsResponse;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -21,6 +21,7 @@ public class BakeryListResponse {
     private List<String> imgPathList;
     private Float rating;
     private Integer reviewsCount;
-    private List<BakeryReviews> bakeryReviewsList; // select
-
+    private String businessHour;
+    private List<BakeryReviewsResponse> bakeryReviewsList; // select
+    private List<String> breadCategoriesList;
 }

--- a/src/main/java/com/depromeet/breadmapbackend/common/enumerate/BreadCategories.java
+++ b/src/main/java/com/depromeet/breadmapbackend/common/enumerate/BreadCategories.java
@@ -1,0 +1,32 @@
+package com.depromeet.breadmapbackend.common.enumerate;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@AllArgsConstructor
+public enum BreadCategories {
+
+    식사빵("식사빵"),
+    구움과자류("구움과자류"),
+    마카롱("마카롱"),
+    케이크("케이크"),
+    크림빵("크림빵"),
+    도넛("도넛"),
+    추억의빵("추억의 빵"),
+    과자류("과자류"),
+    크로와상("크로와상"),
+    쿠키("쿠키"),
+    파이디저트("파이/디저트"),
+    기타("기타")
+    ;
+
+    private final String name;
+
+    public static List<String> breadCategoriesList = Arrays.stream(BreadCategories.values())
+            .map(BreadCategories::getName).collect(Collectors.toList());
+}

--- a/src/main/java/com/depromeet/breadmapbackend/reviews/dto/BakeryReviewsResponse.java
+++ b/src/main/java/com/depromeet/breadmapbackend/reviews/dto/BakeryReviewsResponse.java
@@ -1,6 +1,5 @@
 package com.depromeet.breadmapbackend.reviews.dto;
 
-import com.depromeet.breadmapbackend.common.enumerate.FilterType;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,13 +9,12 @@ import java.util.List;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
-public class ReviewsListResponse {
+public class BakeryReviewsResponse {
 
-    private Long reviewId;
+    private Long bakeryReviewId;
+    private Long memberId;
     private Long bakeryId;
+    private List<String> imagePathList;
     private String contents;
     private Integer rating;
-    private List<FilterType> filterTypeList;
-    private List<String> filterNameList;
-    private List<String> reviewImgPathList;
 }


### PR DESCRIPTION
- 빵집조회에서 API 스펙회의 때 빠진 것들이 있어 모두 추가 완료했습니다.
   + bakeryReviewsList
   + businessHour
   + breadCategoriesList

- BreadCategories enum 도 추가되었습니다. 기존 피그마를 보면 추억의 빵 경우 공백이, 파이/디저트 경우 특수기호가 포함되어 있어 getName()으로 가져와야 했고 나머지는 name이 필요하진 않지만 에러 방지를 위해 모두 추가해주었습니다.
<img width="390" alt="스크린샷 2021-10-17 오전 1 53 01" src="https://user-images.githubusercontent.com/58355531/137595787-57170dd1-ecdf-4ee8-9d72-f3c15fc0ddf5.png">
 
